### PR TITLE
Cert Verify Disable Flag Added, Other Minor Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ A security scanner for HTTP response headers.
 * urllib2
 * urllib
 * json
+* ssl
 
 # Usage
 
 ```
 $ ./hsecscan.py 
 usage: hsecscan.py [-h] [-P] [-p] [-u URL] [-R] [-U User-Agent] [-D DBFILE]
-                   [-d 'POST data'] [-x PROXY] [-a]
+                   [-d 'POST data'] [-x PROXY] [-a] [-c]
 
 A security scanner for HTTP response headers.
 
@@ -43,6 +44,7 @@ optional arguments:
                         Set the proxy server (example: 192.168.1.1:8080).
   -a, --all             Print details for all response headers. Good for check
                         the related RFC.
+  -c, --certverify      Disable SSL certificate verification
 ```
 
 # Example


### PR DESCRIPTION
I added the `-c` flag to allow you to disable ssl cert verification in urllib2 (which required importing ssl, I can add an option to only import this if https in the check_url function). I also changed the scanner request object to use build_opener, then add handlers as needed based on flags. 

The side effect of using build_opener is the open function expects the raw url string and not the ParseResult object passed back to urllib2 as before, but figured it was safe since it's not used anywhere else.

Hope this PR is okay and doesn't make unwanted changes